### PR TITLE
Optimize editing performance

### DIFF
--- a/lib/src/scribble.dart
+++ b/lib/src/scribble.dart
@@ -4,6 +4,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_state_notifier/flutter_state_notifier.dart';
 import 'package:scribble/src/scribble.notifier.dart';
+import 'package:scribble/src/scribble_editing_painter.dart';
 import 'package:scribble/src/scribble_painter.dart';
 import 'package:scribble/src/state/scribble.state.dart';
 
@@ -48,13 +49,19 @@ class _ScribbleState extends State<Scribble> {
         final drawCurrentTool = widget.drawPen && state is Drawing ||
             widget.drawEraser && state is Erasing;
         final child = SizedBox.expand(
-          child: RepaintBoundary(
-            key: widget.notifier.repaintBoundaryKey,
-            child: CustomPaint(
-              painter: ScribblePainter(
-                state: state,
-                drawPointer: widget.drawPen,
-                drawEraser: widget.drawEraser,
+          child: CustomPaint(
+            foregroundPainter: ScribbleEditingPainter(
+              state: state,
+              drawPointer: widget.drawPen,
+              drawEraser: widget.drawEraser,
+            ),
+            child: RepaintBoundary(
+              key: widget.notifier.repaintBoundaryKey,
+              child: CustomPaint(
+                painter: ScribblePainter(
+                  sketch: state.sketch,
+                  scaleFactor: state.scaleFactor,
+                ),
               ),
             ),
           ),

--- a/lib/src/scribble_editing_painter.dart
+++ b/lib/src/scribble_editing_painter.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/rendering.dart';
+import 'package:scribble/scribble.dart';
+import 'package:scribble/src/scribble_painter.dart';
+
+class ScribbleEditingPainter extends CustomPainter with SketchLinePainter {
+  ScribbleEditingPainter({
+    required this.state,
+    required this.drawPointer,
+    required this.drawEraser,
+  });
+
+  final ScribbleState state;
+  final bool drawPointer;
+  final bool drawEraser;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    Paint paint = Paint()..style = PaintingStyle.fill;
+
+    final activeLine = state.map(
+      drawing: (s) => s.activeLine,
+      erasing: (_) => null,
+    );
+    if (activeLine != null) {
+      final path = getPathForLine(activeLine, scaleFactor: state.scaleFactor);
+      if (path != null) {
+        paint.color = Color(activeLine.color);
+        canvas.drawPath(path, paint);
+      }
+    }
+
+    if (state.pointerPosition != null && (state is Drawing && drawPointer || state is Erasing && drawEraser)) {
+      paint.style = state.map(
+        drawing: (_) => PaintingStyle.fill,
+        erasing: (_) => PaintingStyle.stroke,
+      );
+      paint.color = state.map(
+        drawing: (s) => Color(s.selectedColor),
+        erasing: (s) => const Color(0xFF000000),
+      );
+      paint.strokeWidth = 1;
+      canvas.drawCircle(
+        state.pointerPosition!.asOffset,
+        state.selectedWidth / state.scaleFactor,
+        paint,
+      );
+    }
+  }
+
+  @override
+  bool shouldRepaint(ScribbleEditingPainter oldDelegate) {
+    return oldDelegate.state != state;
+  }
+}

--- a/lib/src/scribble_painter.dart
+++ b/lib/src/scribble_painter.dart
@@ -1,78 +1,69 @@
-import 'dart:ui';
-
 import 'package:flutter/rendering.dart';
 import 'package:perfect_freehand/perfect_freehand.dart' as pf;
 import 'package:scribble/scribble.dart';
 
-class ScribblePainter extends CustomPainter {
+class ScribblePainter extends CustomPainter with SketchLinePainter {
   ScribblePainter({
-    required this.state,
-    required this.drawPointer,
-    required this.drawEraser,
+    required this.sketch,
+    required this.scaleFactor,
   });
 
-  final ScribbleState state;
-  final bool drawPointer;
-  final bool drawEraser;
+  final Sketch sketch;
+  final double scaleFactor;
 
-  List<SketchLine> get lines => state.lines;
+  List<SketchLine> get lines => sketch.lines;
 
   @override
   void paint(Canvas canvas, Size size) {
     Paint paint = Paint()..style = PaintingStyle.fill;
 
     for (int i = 0; i < lines.length; ++i) {
-      final line = lines[i];
-      final simulatePressure = line.points.isNotEmpty &&
-          line.points.every((p) => p.pressure == line.points.first.pressure);
-      paint.color = Color(lines[i].color);
-      final points = line.points
-          .map((point) => pf.Point(point.x, point.y, point.pressure))
-          .toList();
-      final outlinePoints = pf.getStroke(
-        points,
-        size: line.width * 2 * state.scaleFactor,
-        simulatePressure: simulatePressure,
-      );
-      final path = Path();
-      if (outlinePoints.isEmpty) {
+      final path = getPathForLine(lines[i]);
+      if (path == null) {
         continue;
-      } else if (outlinePoints.length < 2) {
-        path.addOval(Rect.fromCircle(
-            center: Offset(outlinePoints[0].x, outlinePoints[0].y), radius: 1));
-      } else {
-        path.moveTo(outlinePoints[0].x, outlinePoints[0].y);
-        for (int i = 1; i < outlinePoints.length - 1; ++i) {
-          final p0 = outlinePoints[i];
-          final p1 = outlinePoints[i + 1];
-          path.quadraticBezierTo(
-              p0.x, p0.y, (p0.x + p1.x) / 2, (p0.y + p1.y) / 2);
-        }
       }
       paint.color = Color(lines[i].color);
       canvas.drawPath(path, paint);
-    }
-    if (state.pointerPosition != null &&
-        (state is Drawing && drawPointer || state is Erasing && drawEraser)) {
-      paint.style = state.map(
-        drawing: (_) => PaintingStyle.fill,
-        erasing: (_) => PaintingStyle.stroke,
-      );
-      paint.color = state.map(
-        drawing: (s) => Color(s.selectedColor),
-        erasing: (s) => const Color(0xFF000000),
-      );
-      paint.strokeWidth = 1;
-      canvas.drawCircle(
-        state.pointerPosition!.asOffset,
-        state.selectedWidth / state.scaleFactor,
-        paint,
-      );
     }
   }
 
   @override
   bool shouldRepaint(ScribblePainter oldDelegate) {
-    return oldDelegate.state != state;
+    return oldDelegate.sketch != sketch || oldDelegate.scaleFactor != scaleFactor;
+  }
+}
+
+mixin SketchLinePainter {
+  Path? getPathForLine(SketchLine line, {double scaleFactor = 1.0}) {
+    final simulatePressure = line.points.isNotEmpty && line.points.every((p) => p.pressure == line.points.first.pressure);
+    final points = line.points.map((point) => pf.Point(point.x, point.y, point.pressure)).toList();
+    final outlinePoints = pf.getStroke(
+      points,
+      size: line.width * 2 * scaleFactor,
+      simulatePressure: simulatePressure,
+    );
+    if (outlinePoints.isEmpty) {
+      return null;
+    } else if (outlinePoints.length < 2) {
+      return Path()
+        ..addOval(Rect.fromCircle(
+          center: Offset(outlinePoints[0].x, outlinePoints[0].y),
+          radius: 1,
+        ));
+    } else {
+      final path = Path();
+      path.moveTo(outlinePoints[0].x, outlinePoints[0].y);
+      for (int i = 1; i < outlinePoints.length - 1; ++i) {
+        final p0 = outlinePoints[i];
+        final p1 = outlinePoints[i + 1];
+        path.quadraticBezierTo(
+          p0.x,
+          p0.y,
+          (p0.x + p1.x) / 2,
+          (p0.y + p1.y) / 2,
+        );
+      }
+      return path;
+    }
   }
 }

--- a/lib/src/scribble_sketch.dart
+++ b/lib/src/scribble_sketch.dart
@@ -7,18 +7,24 @@ class ScribbleSketch extends StatelessWidget {
   const ScribbleSketch({
     Key? key,
     required this.sketch,
+    this.scaleFactor = 1,
   }) : super(key: key);
 
   /// The sketch to display
   final Sketch sketch;
 
+  /// How much the widget is scaled at the moment.
+  ///
+  /// Can be used if zoom functionality is needed
+  /// (e.g. through InteractiveViewer) so that the pen width remains the same.
+  final double scaleFactor;
+
   @override
   Widget build(BuildContext context) {
     return CustomPaint(
       painter: ScribblePainter(
-        state: ScribbleState.drawing(sketch: sketch),
-        drawPointer: false,
-        drawEraser: false,
+        sketch: sketch,
+        scaleFactor: 1.0,
       ),
     );
   }

--- a/lib/src/scribble_sketch.dart
+++ b/lib/src/scribble_sketch.dart
@@ -24,7 +24,7 @@ class ScribbleSketch extends StatelessWidget {
     return CustomPaint(
       painter: ScribblePainter(
         sketch: sketch,
-        scaleFactor: 1.0,
+        scaleFactor: scaleFactor,
       ),
     );
   }


### PR DESCRIPTION
I have separated the drawing logic of the editing controls from the sketch drawing logic:
- The ScribblePainter is now only used to draw the sketch, hence it's arguments are replaced with just the sketch.
- The editing controls are drawn by the new ScribbleEditingPainter.

The Problem was, that the sketch got drawn every time the editing controls changed. These include information about the active tool, etc. and the most hurting of them: The **active line** and the **pointer position**. Since these change every frame, the user is editing the sketch, the hole sketch gets rendered every frame, making the repaint boundary useless, that is introduced in the Scribble widget!

Note that the user will instantly notice very slight frame drops, when actively drawing, but does not, if the last frame, in which he takes up the pen, takes way longer, because the screen does not change in this time anyways. That is why we should make the frames, in which the user is drawing very very fast, and shove every big operation to the end of the interaction!